### PR TITLE
[TASK] Don't ignore labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .DS_Store
 .idea
 nbproject
-/var
+/var/*
+!/var/labels
 /vendor
 /public/*
 !/public/typo3conf


### PR DESCRIPTION
Downloaded files for XLF language files are usually stored within :file:`typo3conf/l10n`. When the environment
variable `TYPO3_PATH_ROOT` is set, which is common for all composer-based installations, the XLF language files
are now found outside the document root, available under :file:`var/labels/`.

See: https://forge.typo3.org/issues/85560