### PR TITLE
fix composer scripts PHP Version for 9LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
 	},
 	"scripts":{
 		"typo3-cms-scripts": [
-			"typo3cms install:fixfolderstructure",
-			"typo3cms install:generatepackagestates"
+			"@php vendor/bin/typo3cms install:fixfolderstructure",
+			"@php vendor/bin/typo3cms install:generatepackagestates"
 		],
 		"post-autoload-dump": [
 			"@typo3-cms-scripts"


### PR DESCRIPTION
If the default php version on a system is not PHP 7.2 the typo3-cms-scripts fail, though composer itself is used with the correct version.
The change makes composer scripts use the same PHP Version Composer itself uses.