### PR TITLE
[BUGFIX] Remove PHP platform requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,6 @@
 	"description" : "TYPO3 CMS Base Distribution",
 	"license": "GPL-2.0-or-later",
 	"config": {
-		"platform": {
-			"php": "7.2"
-		},
 		"sort-packages": true
 	},
 	"require": {


### PR DESCRIPTION
The current platform reqs made an update or installation of typo3/cms-* v10.4.7 impossible because Symfony 5 required php ^7.2.5
This fixes #26 at least for fresh installs.

I suggest to remove the PHP platform requirements since it cannot be maintained throughout the whole live cycle of a TYPO3 LTS version.