### PR TITLE
Add type for composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "typo3/cms-base-distribution",
 	"description" : "TYPO3 CMS Base Distribution",
 	"license": "GPL-2.0-or-later",
+	"type": "project",
 	"config": {
 		"platform": {
 			"php": "7.4.1"


### PR DESCRIPTION
Makes the `composer create-project vendor/package-name` command show up on packagist.org
On top using a package type allows to use filter the project e.g.
https://packagist.org/packages/list.json?type=project

![Bildschirmfoto 2021-01-08 um 09 53 58](https://user-images.githubusercontent.com/4623070/103994743-b72ca500-5197-11eb-8c00-9d605c618514.png)