### PR TITLE
[BUGFIX] Set platform string to supported version string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"config": {
 		"platform": {
-			"php": "7.2"
+			"php": "7.2.5"
 		},
 		"sort-packages": true
 	},


### PR DESCRIPTION
The platform version string needs three digits, as advised in the Composer docs (https://github.com/composer/composer/issues/7067 & https://getcomposer.org/doc/06-config.md#platform).

Streamline the version string with TYPO3 Core, using 7.2.5 in v10 and 7.2.5 in v9 (https://github.com/TYPO3/TYPO3.CMS/commit/33471eff99a5b5ccf79e74b6ce434474bb20b669).