### PR TITLE
[BUGFIX] Set platform string to supported version version (v9)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"license": "GPL-2.0-or-later",
 	"config": {
 		"platform": {
-			"php": "7.2"
+			"php": "7.2.5"
 		}
 	},
 	"require": {


### PR DESCRIPTION
Backort of PR #40 to version 9.x, set platform version string with three instead of two digits.