### PR TITLE
[TASK] add config.allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,10 @@
 	"license": "GPL-2.0-or-later",
 	"type": "project",
 	"config": {
+		"allow-plugins": {
+			"typo3/cms-composer-installers": true,
+			"typo3/class-alias-loader": true
+		},
 		"platform": {
 			"php": "7.4.1"
 		},


### PR DESCRIPTION
composer is going to require to setup which which plugins should be
loaded from July 2022. In interactive mode in composer 2.2+, the user is
already asked to add this setting to composer.json. [1]

This allows composer to run obligatory TYPO3 plugins by adding them to
"config.allow-plugins" [1].

References:
 - [1] https://getcomposer.org/doc/06-config.md#allow-plugins

I suggest backporting to 11.x.