### PR TITLE
Use @php to run PHP scripts in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	},
 	"scripts":{
 		"typo3-cms-scripts": [
-			"typo3cms install:fixfolderstructure"
+			"@php vendor/bin/typo3cms install:fixfolderstructure"
 		],
 		"post-autoload-dump": [
 			"@typo3-cms-scripts"


### PR DESCRIPTION
Using the command this way will

- make sure that the same php version is used which was used
  to run the script (and not the default version)
- make it possible to execute the script in some scenarios
  where this would otherwise not be possible