### PR TITLE
[BUGFIX] Add command argument separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To do this, you need to execute the following command and substitute the argumen
 with your own environment configuration.
 
 ```bash
-composer exec typo3cms install:setup \
+composer exec -- typo3cms install:setup \
     --no-interaction \
     --database-user-name=typo3 \
     --database-user-password=typo3 \


### PR DESCRIPTION
Composer demands a command argument separator, whenever arguments beginning with »--« need to bepassed to executable scripts and subcommands.

Since the unattended setup command makes use of this argument type we need to pass this separator
to the script to prevent Composer error messages like »The "--database-user-name" option does not exist«.

Refs #56