### PR TITLE
[TASK] Avoid typo3/cms-extensionmanager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
 		"typo3/cms-core": "dev-main",
 		"typo3/cms-dashboard": "dev-main",
 		"typo3/cms-extbase": "dev-main",
-		"typo3/cms-extensionmanager": "dev-main",
 		"typo3/cms-felogin": "dev-main",
 		"typo3/cms-filelist": "dev-main",
 		"typo3/cms-fluid": "dev-main",


### PR DESCRIPTION
The EM is pretty much useless in composer based
TYPO3 instances and v13 removed dependencies to
it in other extensions. It should no longer be
part of the base distribution.