### PR TITLE
[TASK] Explicitly require unstable doctrine/dbal release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"sort-packages": true
 	},
 	"require": {
+		"doctrine/dbal": "4.0.0-RC2@rc",
 		"typo3/cms-backend": "dev-main",
 		"typo3/cms-belog": "dev-main",
 		"typo3/cms-beuser": "dev-main",


### PR DESCRIPTION
See https://getcomposer.org/doc/04-schema.md#package-links
> If one of your dependencies has a dependency on an unstable
> package you need to explicitly require it as well, along with
> its sufficient stability flag.

Related: https://review.typo3.org/c/Packages/TYPO3.CMS/+/82674