### PR TITLE
[TASK] Remove t3editor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
 		"typo3/cms-seo": "dev-main",
 		"typo3/cms-setup": "dev-main",
 		"typo3/cms-sys-note": "dev-main",
-		"typo3/cms-t3editor": "dev-main",
 		"typo3/cms-tstemplate": "dev-main",
 		"typo3/cms-viewpage": "dev-main",
 		"typo3/cms-webhooks": "dev-main"


### PR DESCRIPTION
EXT:t3editor has been merged into EXT:backend with TYPO3 v13.0. The composer.json file should reflect this change.

Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102440-EXTt3editorMergedIntoEXTbackend.html