### PR TITLE
[TASK] Remove t3editor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
 		"typo3/cms-seo": "^13.1",
 		"typo3/cms-setup": "^13.1",
 		"typo3/cms-sys-note": "^13.1",
-		"typo3/cms-t3editor": "^13.1",
 		"typo3/cms-tstemplate": "^13.1",
 		"typo3/cms-viewpage": "^13.1",
 		"typo3/cms-webhooks": "^13.1"


### PR DESCRIPTION
EXT:t3editor has been merged into EXT:backend with TYPO3 v13.0. The composer.json file should reflect this change.

Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102440-EXTt3editorMergedIntoEXTbackend.html