### PR TITLE
[TASK] Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Get going quickly with TYPO3 CMS.
 
 ## Quickstart
 
-* `composer create-project typo3/cms-base-distribution project-name ^12`
+* `composer create-project typo3/cms-base-distribution project-name ^13`
 * `cd project-name`
 
 ### Setup
@@ -28,19 +28,16 @@ To do this, you need to execute the following command and substitute the argumen
 with your own environment configuration.
 
 ```bash
+export TYPO3_SETUP_ADMIN_PASSWORD=$(tr -dc "_A-Za-z0-9#=$()/" < /dev/urandom | head -c24)
 composer exec -- typo3 setup \
     --no-interaction \
-    --driver=mysqli \
-    --username=typo3 \
-    --password=typo3 \
-    --host=127.0.0.1 \
-    --port=3306 \
-    --dbname=typo3 \
+    --server-type=other \
+    --driver=sqlite \
     --admin-username=admin \
-    --admin-email="info@typo3.org" \
-    --admin-user-password=password \
+    --admin-email="info@example.com" \
     --project-name="My TYPO3 Project" \
-    --create-site="https://localhost/"
+    --create-site="http://localhost:8000/"
+echo "Admin password: ${TYPO3_SETUP_ADMIN_PASSWORD}"
 ```
 
 ### Development server


### PR DESCRIPTION
Avoid suggesting any security relevant credentials like database configuration or admin accounts, instead
interactive `typo3 setup` shall be used.

Also match example site with the development server example and fix `create-project` command line for v13.